### PR TITLE
Add setting API key without env vars

### DIFF
--- a/cryptocompare/cryptocompare.py
+++ b/cryptocompare/cryptocompare.py
@@ -10,6 +10,7 @@ from typing import Union, Optional, List, Dict
 Timestamp = Union[datetime.datetime, datetime.date, int, float]
 
 # API
+_API_KEY = None
 _API_KEY_PARAMETER = ""
 _URL_COIN_LIST = 'https://www.cryptocompare.com/api/data/coinlist?'
 _URL_PRICE = 'https://min-api.cryptocompare.com/data/pricemulti?fsyms={}&tsyms={}'
@@ -38,7 +39,9 @@ def _query_cryptocompare(url: str, errorCheck: bool = True, api_key: str = None)
     :returns: respones, or nothing if errorCheck=True
     :api_key: optional, if you want to add an API Key
     """
-    api_key_parameter = _set_api_key_parameter(api_key)
+    if api_key is None and _API_KEY is not None:
+        api_key = _API_KEY
+    api_key_parameter = _get_api_key_parameter(api_key)
     try:
         response = requests.get(url + api_key_parameter).json()
     except Exception as e:
@@ -75,13 +78,17 @@ def _format_timestamp(timestamp: Timestamp) -> int:
         return int(time.mktime(timestamp.timetuple()))
     return int(timestamp)
 
-
 def _set_api_key_parameter(api_key: str = None) -> str:
+    global _API_KEY
+    _API_KEY = api_key
+    
+def _get_api_key_parameter(api_key: str = None) -> str:
     if api_key is None:
         api_key = os.getenv('CRYPTOCOMPARE_API_KEY')
     if api_key is not None:
-        _API_KEY = "&api_key={}".format(api_key)
-        return _API_KEY
+        global _API_KEY_PARAMETER
+        _API_KEY_PARAMETER = "&api_key={}".format(api_key)
+        return _API_KEY_PARAMETER
     return ""
 
 ###############################################################################

--- a/tests/test_cryptocompare.py
+++ b/tests/test_cryptocompare.py
@@ -99,21 +99,21 @@ class TestCryptoCompare(unittest.TestCase):
         pairs = cryptocompare.get_pairs(exchange='Kraken')
         self.assertEqual('Kraken', pairs[0]['exchange'])
 
-    def test_sets_api_key_using_environment_variable(self):
+    def test_gets_api_key_using_environment_variable(self):
         os.environ["CRYPTOCOMPARE_API_KEY"] = "Key"
-        api_key_parameter = cryptocompare.cryptocompare._set_api_key_parameter(
+        api_key_parameter = cryptocompare.cryptocompare._get_api_key_parameter(
             None)
         assert api_key_parameter == "&api_key=Key"
 
-    def test_sets_api_key_with_no_env_var_and_none_passed(self):
+    def test_gets_api_key_with_no_env_var_and_none_passed(self):
         if os.getenv("CRYPTOCOMPARE_API_KEY"):
             del os.environ['CRYPTOCOMPARE_API_KEY']
-        api_key_parameter = cryptocompare.cryptocompare._set_api_key_parameter(
+        api_key_parameter = cryptocompare.cryptocompare._get_api_key_parameter(
             None)
         assert api_key_parameter == ""
 
-    def test_sets_api_key_passed_in_works(self):
-        api_key_parameter = cryptocompare.cryptocompare._set_api_key_parameter(
+    def test_gets_api_key_passed_in_works(self):
+        api_key_parameter = cryptocompare.cryptocompare._get_api_key_parameter(
             "keytest")
         assert api_key_parameter == "&api_key=keytest"
 


### PR DESCRIPTION
Add possibility to set the _API_KEY through _set_api_key_parameter(), while the original function has been aptly renamed to _get_api_key_parameter().

To stay in line with documentation, _set_api_key_parameter() has been replaced by a function that allows setting the protected _API_KEY variable, which is being used, in case no api_key has been passed to _query_cryptocompare().

This will keep current code, relying on env vars still running, but enables setting the api_key without manipulating environment variables. In case _API_KEY is set, it will override any API keys set in env vars.

The code should now work as described on https://pypi.org/project/cryptocompare/.

_API_KEY_PARAMETER should be assigned a value, as intended, through the addition of `global` before the assignment in _get_api_key_parameter().