### PR TITLE
Updated price history APIs(day/hour/minute) to v2 and additional functions

### DIFF
--- a/cryptocompare/cryptocompare.py
+++ b/cryptocompare/cryptocompare.py
@@ -165,6 +165,57 @@ def get_historical_price_day(coin: str, currency: str = CURRENCY, limit: int = L
     return None
 
 
+def get_historical_price_day_from(coin: str, currency: str = CURRENCY,
+                                 exchange: str = 'CCCAGG', toTs: Timestamp = time.time(),
+                                 fromTs: Timestamp = 0, delay: float = 0.2) -> Optional[Dict]:
+    """
+    Get historical price (day).
+
+    :param coin: symbolic name of the coin (e.g. BTC)
+    :param currency: short hand description of the currency (e.g. EUR)
+    :param exchange: exchange to use (default: 'CCCAGG')
+    :param toTs: return data before this timestamp. (Unix epoch time or datetime object)
+    :param fromTs: return data after this timestamp. (Unix epoch time or datetime object)
+    :param delay: time delay for API rate limit (default: 300 calls / 1 minute)
+    :returns: dict of coin and currency price pairs
+    """
+    allHist = []
+    toTs = _format_timestamp(toTs)
+    fromTs = _format_timestamp(fromTs)
+
+    while fromTs <= toTs:
+        p = get_historical_price_day(coin, currency, LIMIT, exchange, toTs)
+        if p is None:
+            return None
+
+        validHist = [elem for elem in p if elem['time'] >= fromTs and elem['open'] != 0 and elem['close'] != 0]
+        allHist = validHist + allHist
+
+        if len(validHist) < len(p):
+            break
+        toTs = (min(p, key = lambda x:x['time']))['time'] - 1
+        time.sleep(delay)
+
+    return allHist
+
+
+def get_historical_price_day_all(coin: str, currency: str = CURRENCY,
+                                 exchange: str = 'CCCAGG') -> Optional[Dict]:
+    """
+    Get historical price (day, all).
+
+    :param coin: symbolic name of the coin (e.g. BTC)
+    :param currency: short hand description of the currency (e.g. EUR)
+    :param exchange: exchange to use (default: 'CCCAGG')
+    :returns: dict of coin and currency price pairs
+    """
+    response = _query_cryptocompare(
+        _URL_HIST_PRICE_DAY.format(coin, _format_parameter(currency), 1, exchange, time.time()) + "&allData=true")
+    if response:
+        return response['Data']['Data']
+    return None
+
+
 def get_historical_price_hour(coin: str, currency: str = CURRENCY, limit: int = LIMIT,
                               exchange: str = 'CCCAGG', toTs: Timestamp = time.time()) -> Optional[Dict]:
     """
@@ -183,6 +234,38 @@ def get_historical_price_hour(coin: str, currency: str = CURRENCY, limit: int = 
     if response:
         return response['Data']['Data']
     return None
+
+
+def get_historical_price_hour_from(coin: str, currency: str = CURRENCY,
+                                 exchange: str = 'CCCAGG', toTs: Timestamp = time.time(),
+                                 fromTs: Timestamp = 0, delay: float = 0.2) -> Optional[Dict]:
+    """
+    Get historical price (day).
+
+    :param coin: symbolic name of the coin (e.g. BTC)
+    :param currency: short hand description of the currency (e.g. EUR)
+    :param exchange: exchange to use (default: 'CCCAGG')
+    :param toTs: return data before this timestamp. (Unix epoch time or datetime object)
+    :param fromTs: return data after this timestamp. (Unix epoch time or datetime object)
+    :param delay: time delay for API rate limit (default: 300 calls / 1 minute)
+    :returns: dict of coin and currency price pairs
+    """
+    allHist = []
+
+    while fromTs <= toTs:
+        p = get_historical_price_hour(coin, currency, LIMIT, exchange, toTs)
+        if p is None:
+            return None
+
+        validHist = [elem for elem in p if elem['time'] >= fromTs and elem['open'] != 0 and elem['close'] != 0]
+        allHist = validHist + allHist
+
+        if len(validHist) < len(p):
+            break
+        toTs = (min(p, key = lambda x:x['time']))['time'] - 1
+        time.sleep(delay)
+
+    return allHist
 
 
 def get_historical_price_minute(coin: str, currency: str = CURRENCY, limit: int = LIMIT,

--- a/cryptocompare/cryptocompare.py
+++ b/cryptocompare/cryptocompare.py
@@ -16,9 +16,9 @@ _URL_PRICE = 'https://min-api.cryptocompare.com/data/pricemulti?fsyms={}&tsyms={
 _URL_PRICE_MULTI = 'https://min-api.cryptocompare.com/data/pricemulti?fsyms={}&tsyms={}'
 _URL_PRICE_MULTI_FULL = 'https://min-api.cryptocompare.com/data/pricemultifull?fsyms={}&tsyms={}'
 _URL_HIST_PRICE = 'https://min-api.cryptocompare.com/data/pricehistorical?fsym={}&tsyms={}&ts={}&e={}'
-_URL_HIST_PRICE_DAY = 'https://min-api.cryptocompare.com/data/histoday?fsym={}&tsym={}&limit={}&e={}&toTs={}'
-_URL_HIST_PRICE_HOUR = 'https://min-api.cryptocompare.com/data/histohour?fsym={}&tsym={}&limit={}&e={}&toTs={}'
-_URL_HIST_PRICE_MINUTE = 'https://min-api.cryptocompare.com/data/histominute?fsym={}&tsym={}&limit={}&e={}&toTs={}'
+_URL_HIST_PRICE_DAY = 'https://min-api.cryptocompare.com/data/v2/histoday?fsym={}&tsym={}&limit={}&e={}&toTs={}'
+_URL_HIST_PRICE_HOUR = 'https://min-api.cryptocompare.com/data/v2/histohour?fsym={}&tsym={}&limit={}&e={}&toTs={}'
+_URL_HIST_PRICE_MINUTE = 'https://min-api.cryptocompare.com/data/v2/histominute?fsym={}&tsym={}&limit={}&e={}&toTs={}'
 _URL_AVG = 'https://min-api.cryptocompare.com/data/generateAvg?fsym={}&tsym={}&e={}'
 _URL_EXCHANGES = 'https://www.cryptocompare.com/api/data/exchanges?'
 _URL_PAIRS = 'https://min-api.cryptocompare.com/data/pair/mapping/exchange?e={}'
@@ -161,7 +161,7 @@ def get_historical_price_day(coin: str, currency: str = CURRENCY, limit: int = L
     response = _query_cryptocompare(
         _URL_HIST_PRICE_DAY.format(coin, _format_parameter(currency), limit, exchange, _format_timestamp(toTs)))
     if response:
-        return response['Data']
+        return response['Data']['Data']
     return None
 
 
@@ -181,7 +181,7 @@ def get_historical_price_hour(coin: str, currency: str = CURRENCY, limit: int = 
     response = _query_cryptocompare(
         _URL_HIST_PRICE_HOUR.format(coin, _format_parameter(currency), limit, exchange, _format_timestamp(toTs)))
     if response:
-        return response['Data']
+        return response['Data']['Data']
     return None
 
 
@@ -200,7 +200,7 @@ def get_historical_price_minute(coin: str, currency: str = CURRENCY, limit: int 
     response = _query_cryptocompare(
         _URL_HIST_PRICE_MINUTE.format(coin, _format_parameter(currency), limit, exchange, _format_timestamp(toTs)))
     if response:
-        return response['Data']
+        return response['Data']['Data']
     return None
 
 

--- a/cryptocompare/cryptocompare.py
+++ b/cryptocompare/cryptocompare.py
@@ -147,7 +147,7 @@ def get_historical_price(coin: str, currency: str = CURRENCY, timestamp: Timesta
 
 
 def get_historical_price_day(coin: str, currency: str = CURRENCY, limit: int = LIMIT,
-                             exchange: str = 'CCCAGG', toTs: Timestamp = time.time()) -> Optional[Dict]:
+                             exchange: str = 'CCCAGG', toTs: Timestamp = time.time()) -> Optional[List[Dict]]:
     """
     Get historical price (day).
 
@@ -167,7 +167,7 @@ def get_historical_price_day(coin: str, currency: str = CURRENCY, limit: int = L
 
 def get_historical_price_day_from(coin: str, currency: str = CURRENCY,
                                  exchange: str = 'CCCAGG', toTs: Timestamp = time.time(),
-                                 fromTs: Timestamp = 0, delay: float = 0.2) -> Optional[Dict]:
+                                 fromTs: Timestamp = 0, delay: float = 0.2) -> Optional[List[Dict]]:
     """
     Get historical price (day).
 
@@ -179,28 +179,28 @@ def get_historical_price_day_from(coin: str, currency: str = CURRENCY,
     :param delay: time delay for API rate limit (default: 300 calls / 1 minute)
     :returns: dict of coin and currency price pairs
     """
-    allHist = []
-    toTs = _format_timestamp(toTs)
-    fromTs = _format_timestamp(fromTs)
+    allHist: List[Dict] = []
+    toTs_i = _format_timestamp(toTs)
+    fromTs_i = _format_timestamp(fromTs)
 
-    while fromTs <= toTs:
-        p = get_historical_price_day(coin, currency, LIMIT, exchange, toTs)
+    while fromTs_i <= toTs_i:
+        p = get_historical_price_day(coin, _format_parameter(currency), LIMIT, exchange, toTs_i)
         if p is None:
             return None
 
-        validHist = [elem for elem in p if elem['time'] >= fromTs and elem['open'] != 0 and elem['close'] != 0]
+        validHist = [elem for elem in p if elem['time'] >= fromTs_i and elem['open'] != 0 and elem['close'] != 0]
         allHist = validHist + allHist
 
         if len(validHist) < len(p):
             break
-        toTs = (min(p, key = lambda x:x['time']))['time'] - 1
+        toTs_i = (min(p, key = lambda x:x['time']))['time'] - 1
         time.sleep(delay)
 
     return allHist
 
 
 def get_historical_price_day_all(coin: str, currency: str = CURRENCY,
-                                 exchange: str = 'CCCAGG') -> Optional[Dict]:
+                                 exchange: str = 'CCCAGG') -> Optional[List[Dict]]:
     """
     Get historical price (day, all).
 
@@ -217,7 +217,7 @@ def get_historical_price_day_all(coin: str, currency: str = CURRENCY,
 
 
 def get_historical_price_hour(coin: str, currency: str = CURRENCY, limit: int = LIMIT,
-                              exchange: str = 'CCCAGG', toTs: Timestamp = time.time()) -> Optional[Dict]:
+                              exchange: str = 'CCCAGG', toTs: Timestamp = time.time()) -> Optional[List[Dict]]:
     """
     Get historical price (hourly).
 
@@ -238,7 +238,7 @@ def get_historical_price_hour(coin: str, currency: str = CURRENCY, limit: int = 
 
 def get_historical_price_hour_from(coin: str, currency: str = CURRENCY,
                                  exchange: str = 'CCCAGG', toTs: Timestamp = time.time(),
-                                 fromTs: Timestamp = 0, delay: float = 0.2) -> Optional[Dict]:
+                                 fromTs: Timestamp = 0, delay: float = 0.2) -> Optional[List[Dict]]:
     """
     Get historical price (day).
 
@@ -250,26 +250,28 @@ def get_historical_price_hour_from(coin: str, currency: str = CURRENCY,
     :param delay: time delay for API rate limit (default: 300 calls / 1 minute)
     :returns: dict of coin and currency price pairs
     """
-    allHist = []
+    allHist: List[Dict] = []
+    toTs_i = _format_timestamp(toTs)
+    fromTs_i = _format_timestamp(fromTs)
 
-    while fromTs <= toTs:
-        p = get_historical_price_hour(coin, currency, LIMIT, exchange, toTs)
+    while fromTs_i <= toTs_i:
+        p = get_historical_price_hour(coin, _format_parameter(currency), 2000, exchange, toTs_i)
         if p is None:
             return None
 
-        validHist = [elem for elem in p if elem['time'] >= fromTs and elem['open'] != 0 and elem['close'] != 0]
+        validHist = [elem for elem in p if elem['time'] >= fromTs_i and elem['open'] != 0 and elem['close'] != 0]
         allHist = validHist + allHist
 
         if len(validHist) < len(p):
             break
-        toTs = (min(p, key = lambda x:x['time']))['time'] - 1
+        toTs_i = (min(p, key = lambda x:x['time']))['time'] - 1
         time.sleep(delay)
 
     return allHist
 
 
 def get_historical_price_minute(coin: str, currency: str = CURRENCY, limit: int = LIMIT,
-                                exchange: str = 'CCCAGG', toTs: Timestamp = time.time()) -> Optional[Dict]:
+                                exchange: str = 'CCCAGG', toTs: Timestamp = time.time()) -> Optional[List[Dict]]:
     """
     Get historical price (minute).
 

--- a/cryptocompare/cryptocompare.py
+++ b/cryptocompare/cryptocompare.py
@@ -23,6 +23,8 @@ _URL_AVG = 'https://min-api.cryptocompare.com/data/generateAvg?fsym={}&tsym={}&e
 _URL_EXCHANGES = 'https://www.cryptocompare.com/api/data/exchanges?'
 _URL_PAIRS = 'https://min-api.cryptocompare.com/data/pair/mapping/exchange?e={}'
 
+_MAX_LIMIT_HISTO_API = 2000
+
 # DEFAULTS
 CURRENCY = 'EUR'
 LIMIT = 1440
@@ -184,7 +186,7 @@ def get_historical_price_day_from(coin: str, currency: str = CURRENCY,
     fromTs_i = _format_timestamp(fromTs)
 
     while fromTs_i <= toTs_i:
-        p = get_historical_price_day(coin, _format_parameter(currency), LIMIT, exchange, toTs_i)
+        p = get_historical_price_day(coin, _format_parameter(currency), _MAX_LIMIT_HISTO_API, exchange, toTs_i)
         if p is None:
             return None
 
@@ -255,7 +257,7 @@ def get_historical_price_hour_from(coin: str, currency: str = CURRENCY,
     fromTs_i = _format_timestamp(fromTs)
 
     while fromTs_i <= toTs_i:
-        p = get_historical_price_hour(coin, _format_parameter(currency), 2000, exchange, toTs_i)
+        p = get_historical_price_hour(coin, _format_parameter(currency), _MAX_LIMIT_HISTO_API, exchange, toTs_i)
         if p is None:
             return None
 

--- a/tests/test_cryptocompare.py
+++ b/tests/test_cryptocompare.py
@@ -3,6 +3,7 @@ import time
 import unittest
 import cryptocompare
 import datetime
+import calendar
 import os
 
 
@@ -67,11 +68,40 @@ class TestCryptoCompare(unittest.TestCase):
         for frame in price:
             self.assertIn('time', frame)
 
+    def test_price_day_all(self):
+        coin = 'BTC'
+        curr = 'USD'
+        price = cryptocompare.get_historical_price_day_all(
+            coin, currency=curr, exchange='CCCAGG')
+        self.assertTrue(len(price) > 1)
+        for frame in price:
+            self.assertIn('time', frame)
+
+    def test_price_day_from(self):
+        coin = 'BTC'
+        curr = 'USD'
+        price = cryptocompare.get_historical_price_day_from(
+            coin, currency=curr, exchange='CCCAGG', toTs=int(calendar.timegm(datetime.datetime(2019, 6, 6).timetuple())),
+            fromTs = int(calendar.timegm(datetime.datetime(2019, 6, 4).timetuple())))
+        self.assertTrue(len(price) == 3)
+        for frame in price:
+            self.assertIn('time', frame)
+
     def test_price_hour(self):
         coin = 'BTC'
         curr = 'USD'
         price = cryptocompare.get_historical_price_hour(
             coin, currency=curr, limit=3, exchange='CCCAGG', toTs=datetime.datetime(2019, 6, 6, 12))
+        for frame in price:
+            self.assertIn('time', frame)
+
+    def test_price_hour_from(self):
+        coin = 'BTC'
+        curr = 'USD'
+        price = cryptocompare.get_historical_price_hour_from(
+            coin, currency=curr, exchange='CCCAGG', toTs=int(calendar.timegm(datetime.datetime(2019, 6, 6, 3, 0, 0).timetuple())),
+            fromTs = int(calendar.timegm(datetime.datetime(2019, 6, 6, 1, 0, 0).timetuple())))
+        self.assertTrue(len(price) == 3)
         for frame in price:
             self.assertIn('time', frame)
 


### PR DESCRIPTION
- Updated price history APIs to use v2 link(https://min-api.cryptocompare.com/data/**v2**/histo~)
- Added 3 methods
  - get_historical_price_day_all
    - retrieves all daily price history using `allData` parameter (see https://min-api.cryptocompare.com/documentation?key=Historical&cat=dataHistoday)
  - get_historical_price_day_from
    - retrieves daily price history of fromTs ~ toTs (both inclusive)
    - because of API rate limit, it sleeps `delay` seconds for each API call
  - get_historical_price_hour_from
    - retrieves hourly price history of fromTs ~ toTs (both inclusive)
    - because of API rate limit, it sleeps `delay` seconds for each API call


  